### PR TITLE
Add io.sentry:sentry-android to dependency list

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ and in the dependencies part of your app.gradle add:
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.squareup.okhttp3:okhttp:3.12.1'
     compile 'com.googlecode.libphonenumber:libphonenumber:8.4.2'
+    compile 'io.sentry:sentry-android:1.7.16'
 ```
 
 ### App Bar


### PR DESCRIPTION
`io.sentry:sentry-android` is mentioned in the [v3.20.0 changelog](https://github.com/idnow/de.idnow.android/tree/de.idnow.android-3.20.0#3200), however, it was not added to the [dependency list](https://github.com/idnow/de.idnow.android/tree/de.idnow.android-3.20.0#additional-dependencies-to-add-in-your-appgradle).